### PR TITLE
INTERLOK-4066 Add a new scriptContentEncoding to specify the encoding of the script file.

### DIFF
--- a/src/main/java/com/adaptris/core/scripting/services/EmbeddedScriptingService.java
+++ b/src/main/java/com/adaptris/core/scripting/services/EmbeddedScriptingService.java
@@ -2,7 +2,9 @@ package com.adaptris.core.scripting.services;
 
 import java.io.Reader;
 import java.io.StringReader;
+
 import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -10,25 +12,24 @@ import com.adaptris.annotation.MarshallingCDATA;
 import com.adaptris.core.BranchingServiceCollection;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Supports arbitary scripting languges that are supported by JSR223.
  * <p>
- * You should take care when configuring this class; it can present an audit trail issue when used
- * in combination with
+ * You should take care when configuring this class; it can present an audit trail issue when used in combination with
  *
- * {@link com.adaptris.core.services.dynamic.DynamicServiceExecutor} if your script executes
- * arbitrary system commands. In that situation, all commands will be executed with the current
- * users permissions and may be subject to the virtual machines security manager.
+ * {@link com.adaptris.core.services.dynamic.DynamicServiceExecutor} if your script executes arbitrary system commands. In that situation,
+ * all commands will be executed with the current users permissions and may be subject to the virtual machines security manager.
  * </p>
  * <p>
- * The script is executed and the AdaptrisMessage that is due to be processed is bound against the
- * key "message" and an instance of org.slf4j.Logger is also bound to key "log". These can be used
- * as a standard variable within the script.
+ * The script is executed and the AdaptrisMessage that is due to be processed is bound against the key "message" and an instance of
+ * org.slf4j.Logger is also bound to key "log". These can be used as a standard variable within the script.
  * </p>
  * <p>
- * Note that this class can be used as the selector as part of a {@link BranchingServiceCollection}.
- * If used as such, then you need to remember to invoke
- * {@link com.adaptris.core.AdaptrisMessage#setNextServiceId(String)} as part of the script and
+ * Note that this class can be used as the selector as part of a {@link BranchingServiceCollection}. If used as such, then you need to
+ * remember to invoke {@link com.adaptris.core.AdaptrisMessage#setNextServiceId(String)} as part of the script and
  * {@link #setBranchingEnabled(Boolean)} should be true.
  * <p>
  *
@@ -40,10 +41,18 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("embedded-scripting-service")
 @AdapterComponent
 @ComponentProfile(summary = "Execute an embedded JSR223 script", tag = "service,scripting", branchSelector = true)
-@DisplayOrder(order = {"language", "script", "branchingEnabled"})
+@DisplayOrder(order = { "language", "script", "branchingEnabled" })
 public class EmbeddedScriptingService extends ScriptingServiceImp {
 
+  /**
+   * Set the contents of the script.
+   *
+   * @param script
+   *          the script
+   */
   @MarshallingCDATA
+  @Getter
+  @Setter
   private String script;
 
   public EmbeddedScriptingService() {
@@ -53,20 +62,6 @@ public class EmbeddedScriptingService extends ScriptingServiceImp {
   public EmbeddedScriptingService(String uniqueId) {
     this();
     setUniqueId(uniqueId);
-  }
-
-
-  public String getScript() {
-    return script;
-  }
-
-  /**
-   * Set the contents of the script.
-   *
-   * @param s the script
-   */
-  public void setScript(String s) {
-    script = s;
   }
 
   @Override
@@ -79,4 +74,5 @@ public class EmbeddedScriptingService extends ScriptingServiceImp {
     setLanguage(lang);
     return this;
   }
+
 }

--- a/src/main/java/com/adaptris/core/scripting/services/ScriptingService.java
+++ b/src/main/java/com/adaptris/core/scripting/services/ScriptingService.java
@@ -4,50 +4,78 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import javax.validation.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.fs.FsWorker;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
 /**
  * Supports arbitary scripting languges that are supported by JSR223.
  * <p>
  * You should take care when configuring this class; it can present an audit trail issue when used in combination with
- * {@link com.adaptris.core.services.dynamic.DynamicServiceExecutor} if your script executes arbitrary system commands. In that
- * situation, all commands will be executed with the current users permissions and may be subject to the virtual machines security
- * manager.
+ * {@link com.adaptris.core.services.dynamic.DynamicServiceExecutor} if your script executes arbitrary system commands. In that situation,
+ * all commands will be executed with the current users permissions and may be subject to the virtual machines security manager.
  * </p>
  * <p>
- * The script is executed and the AdaptrisMessage that is due to be processed is bound against the key "message" and an instance
- * of org.slf4j.Logger is also bound to key "log". These can be used as a standard variable within the script.
+ * The script is executed and the AdaptrisMessage that is due to be processed is bound against the key "message" and an instance of
+ * org.slf4j.Logger is also bound to key "log". These can be used as a standard variable within the script.
  * </p>
  * <p>
- * Note that this class can be used as the selector as part of a {@link com.adaptris.core.BranchingServiceCollection}. If used as
- * such, then you need
- * to remember to invoke {@link com.adaptris.core.AdaptrisMessage#setNextServiceId(String)} as part of the script and {@link
- * #setBranchingEnabled(Boolean)}
- * should be true.
+ * Note that this class can be used as the selector as part of a {@link com.adaptris.core.BranchingServiceCollection}. If used as such, then
+ * you need to remember to invoke {@link com.adaptris.core.AdaptrisMessage#setNextServiceId(String)} as part of the script and
+ * {@link #setBranchingEnabled(Boolean)} should be true.
  * <p>
- * 
+ *
  * @config scripting-service
- * 
- * 
+ *
+ *
  * @author lchan
- * 
+ *
  */
 @XStreamAlias("scripting-service")
 @AdapterComponent
 @ComponentProfile(summary = "Execute a JSR223 script stored on the filesystem", tag = "service,scripting", branchSelector = true)
-@DisplayOrder(order = {"language", "scriptFilename", "branchingEnabled"})
+@DisplayOrder(order = { "language", "scriptFilename", "scriptContentEncoding", "branchingEnabled" })
 public class ScriptingService extends ScriptingServiceImp {
 
+  /**
+   * Set the contents of the script.
+   *
+   * @param scriptFilename
+   *          the file name of the script to execute
+   */
   @NotBlank
+  @NonNull
+  @Getter
+  @Setter
   private String scriptFilename;
+
+  /**
+   * @param scriptContentEncoding
+   *          the encoding of the script file. Default to UTF-8
+   */
+
+  @InputFieldDefault("UTF-8")
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private String scriptContentEncoding = StandardCharsets.UTF_8.name();
+
   public ScriptingService() {
     super();
   }
@@ -55,20 +83,6 @@ public class ScriptingService extends ScriptingServiceImp {
   public ScriptingService(String uniqueId) {
     this();
     setUniqueId(uniqueId);
-  }
-
-
-  public String getScriptFilename() {
-    return scriptFilename;
-  }
-
-  /**
-   * Set the contents of the script.
-   *
-   * @param s the script
-   */
-  public void setScriptFilename(String s) {
-    scriptFilename = Args.notBlank(s, "scriptFilename");
   }
 
   @Override
@@ -85,6 +99,7 @@ public class ScriptingService extends ScriptingServiceImp {
 
   @Override
   protected Reader createReader() throws IOException {
-    return new FileReader(getScriptFilename());
+    return new FileReader(getScriptFilename(), Charset.forName(scriptContentEncoding));
   }
+
 }

--- a/src/main/java/com/adaptris/core/scripting/services/ScriptingService.java
+++ b/src/main/java/com/adaptris/core/scripting/services/ScriptingService.java
@@ -25,7 +25,7 @@ import lombok.NonNull;
 import lombok.Setter;
 
 /**
- * Supports arbitary scripting languges that are supported by JSR223.
+ * Supports arbitrary scripting languages that are supported by JSR223.
  * <p>
  * You should take care when configuring this class; it can present an audit trail issue when used in combination with
  * {@link com.adaptris.core.services.dynamic.DynamicServiceExecutor} if your script executes arbitrary system commands. In that situation,

--- a/src/main/java/com/adaptris/core/scripting/services/ScriptingServiceImp.java
+++ b/src/main/java/com/adaptris/core/scripting/services/ScriptingServiceImp.java
@@ -2,11 +2,14 @@ package com.adaptris.core.scripting.services;
 
 import java.io.IOException;
 import java.io.Reader;
+
 import javax.script.Bindings;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.validation.constraints.NotBlank;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
@@ -30,22 +33,21 @@ public abstract class ScriptingServiceImp extends ServiceImp implements DynamicP
   /**
    * Set the JSR223 language the the script is written in.
    * <p>
-   * Depending on the language choice, you may need additional libraries that are not normally
-   * shipped with a standard Interlok distribution.
+   * Depending on the language choice, you may need additional libraries that are not normally shipped with a standard Interlok
+   * distribution.
    * </p>
    */
   @NotBlank
   private String language;
   private transient ScriptEngine engine;
   /**
-   * Specify whether or not this service is branching so it can be used as part of a
-   * {@link BranchingServiceCollection}.
+   * Specify whether or not this service is branching so it can be used as part of a {@link BranchingServiceCollection}.
    */
   @InputFieldDefault("false")
   @AdvancedConfig
   private Boolean branchingEnabled;
   private transient boolean nashornWarningLogged = false;
-  
+
   static {
     System.setProperty("polyglot.js.nashorn-compat", "true");
   }
@@ -84,7 +86,9 @@ public abstract class ScriptingServiceImp extends ServiceImp implements DynamicP
       Args.notBlank(getLanguage(), "language");
       ScriptEngineManager engineManager = new ScriptEngineManager(this.getClass().getClassLoader());
       if (ScriptingUtil.dependsOnNashorn(engineManager, getLanguage())) {
-        LoggingHelper.logWarning(nashornWarningLogged, () -> nashornWarningLogged = true, "Nashorn script engine is deprecated and will be removed in Java 17. " + "If you want to keep using a javascript engine you should consider using GraalJS instead.");
+        LoggingHelper.logWarning(nashornWarningLogged, () -> nashornWarningLogged = true,
+            "Nashorn script engine is deprecated and will be removed in Java 17. "
+                + "If you want to keep using a javascript engine you should consider using GraalJS instead.");
       }
       String error = String.format("getEngineByName(\'%s\')", getLanguage());
       engine = Args.notNull(engineManager.getEngineByName(getLanguage()), error);
@@ -101,19 +105,19 @@ public abstract class ScriptingServiceImp extends ServiceImp implements DynamicP
   /**
    * Set the JSR223 language the the script is written in.
    * <p>
-   * Depending on the language choice, you may need additional libraries that are not normally
-   * shipped with a standard Interlok distribution.
+   * Depending on the language choice, you may need additional libraries that are not normally shipped with a standard Interlok
+   * distribution.
    * </p>
    */
   public String getLanguage() {
-    return this.language;
+    return language;
   }
 
   /**
    * Set the JSR223 language the the script is written in.
    * <p>
-   * Depending on the language choice, you may need additional libraries that are not normally
-   * shipped with a standard Interlok distribution.
+   * Depending on the language choice, you may need additional libraries that are not normally shipped with a standard Interlok
+   * distribution.
    * </p>
    */
   public void setLanguage(final String language) {
@@ -121,19 +125,16 @@ public abstract class ScriptingServiceImp extends ServiceImp implements DynamicP
   }
 
   /**
-   * Specify whether or not this service is branching so it can be used as part of a
-   * {@link BranchingServiceCollection}.
+   * Specify whether or not this service is branching so it can be used as part of a {@link BranchingServiceCollection}.
    */
   public Boolean getBranchingEnabled() {
-    return this.branchingEnabled;
+    return branchingEnabled;
   }
 
   /**
-   * Specify whether or not this service is branching so it can be used as part of a
-   * {@link BranchingServiceCollection}.
+   * Specify whether or not this service is branching so it can be used as part of a {@link BranchingServiceCollection}.
    */
   public void setBranchingEnabled(final Boolean branchingEnabled) {
     this.branchingEnabled = branchingEnabled;
   }
 }
-

--- a/src/main/java/com/adaptris/core/scripting/services/ScriptingServiceImp.java
+++ b/src/main/java/com/adaptris/core/scripting/services/ScriptingServiceImp.java
@@ -5,7 +5,6 @@ import java.io.Reader;
 
 import javax.script.Bindings;
 import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
 import javax.validation.constraints.NotBlank;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -18,10 +17,13 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.DynamicPollingTemplate;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.scripting.utils.ScriptEngineUtils;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.core.util.LoggingHelper;
-import com.adaptris.core.util.ScriptingUtil;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 
 /**
  * Base class for enabling JSR223 enabled scripting languages.
@@ -30,6 +32,7 @@ import com.adaptris.core.util.ScriptingUtil;
  * @author lchan
  */
 public abstract class ScriptingServiceImp extends ServiceImp implements DynamicPollingTemplate.TemplateProvider {
+
   /**
    * Set the JSR223 language the the script is written in.
    * <p>
@@ -38,18 +41,23 @@ public abstract class ScriptingServiceImp extends ServiceImp implements DynamicP
    * </p>
    */
   @NotBlank
+  @NonNull
+  @Getter
+  @Setter
   private String language;
   private transient ScriptEngine engine;
+
   /**
    * Specify whether or not this service is branching so it can be used as part of a {@link BranchingServiceCollection}.
    */
   @InputFieldDefault("false")
   @AdvancedConfig
+  @Getter
+  @Setter
   private Boolean branchingEnabled;
-  private transient boolean nashornWarningLogged = false;
 
   static {
-    System.setProperty("polyglot.js.nashorn-compat", "true");
+    ScriptEngineUtils.nashornCompat();
   }
 
   public ScriptingServiceImp() {
@@ -84,14 +92,7 @@ public abstract class ScriptingServiceImp extends ServiceImp implements DynamicP
   public void prepare() throws CoreException {
     try {
       Args.notBlank(getLanguage(), "language");
-      ScriptEngineManager engineManager = new ScriptEngineManager(this.getClass().getClassLoader());
-      if (ScriptingUtil.dependsOnNashorn(engineManager, getLanguage())) {
-        LoggingHelper.logWarning(nashornWarningLogged, () -> nashornWarningLogged = true,
-            "Nashorn script engine is deprecated and will be removed in Java 17. "
-                + "If you want to keep using a javascript engine you should consider using GraalJS instead.");
-      }
-      String error = String.format("getEngineByName(\'%s\')", getLanguage());
-      engine = Args.notNull(engineManager.getEngineByName(getLanguage()), error);
+      engine = ScriptEngineUtils.getEngineByName(getLanguage(), this.getClass().getClassLoader());
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
@@ -102,39 +103,4 @@ public abstract class ScriptingServiceImp extends ServiceImp implements DynamicP
     return BooleanUtils.toBooleanDefaultIfNull(getBranchingEnabled(), false);
   }
 
-  /**
-   * Set the JSR223 language the the script is written in.
-   * <p>
-   * Depending on the language choice, you may need additional libraries that are not normally shipped with a standard Interlok
-   * distribution.
-   * </p>
-   */
-  public String getLanguage() {
-    return language;
-  }
-
-  /**
-   * Set the JSR223 language the the script is written in.
-   * <p>
-   * Depending on the language choice, you may need additional libraries that are not normally shipped with a standard Interlok
-   * distribution.
-   * </p>
-   */
-  public void setLanguage(final String language) {
-    this.language = language;
-  }
-
-  /**
-   * Specify whether or not this service is branching so it can be used as part of a {@link BranchingServiceCollection}.
-   */
-  public Boolean getBranchingEnabled() {
-    return branchingEnabled;
-  }
-
-  /**
-   * Specify whether or not this service is branching so it can be used as part of a {@link BranchingServiceCollection}.
-   */
-  public void setBranchingEnabled(final Boolean branchingEnabled) {
-    this.branchingEnabled = branchingEnabled;
-  }
 }

--- a/src/main/java/com/adaptris/core/scripting/services/conditional/conditions/ConditionFunction.java
+++ b/src/main/java/com/adaptris/core/scripting/services/conditional/conditions/ConditionFunction.java
@@ -4,28 +4,31 @@ import javax.script.Bindings;
 import javax.script.Invocable;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.MarshallingCDATA;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.scripting.utils.ScriptEngineUtils;
 import com.adaptris.core.services.conditional.conditions.ConditionImpl;
-import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * A javascript condition.
  *
  * <p>
- * This makes use of the {@link Invocable} extension to {@link ScriptEngine}, to allow you to define
- * the function that will be executed to evaluate the condition. The function name should always be
- * {@code evaluateScript}; take a single parameter (in this case it will be the current
- * {@link AdaptrisMessage}; and return {@code true or false}. For instance to check a specific
- * metadata value then you might have this function definition
+ * This makes use of the {@link Invocable} extension to {@link ScriptEngine}, to allow you to define the function that will be executed to
+ * evaluate the condition. The function name should always be {@code evaluateScript}; take a single parameter (in this case it will be the
+ * current {@link AdaptrisMessage}; and return {@code true or false}. For instance to check a specific metadata value then you might have
+ * this function definition
  *
  * <pre>
  * {@code
@@ -36,26 +39,30 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * </pre>
  * </p>
  * <p>
- * Similar to {@link com.adaptris.core.services.EmbeddedScriptingService}; the logger is bound as
- * {@code log}.
+ * Similar to {@link com.adaptris.core.services.EmbeddedScriptingService}; the logger is bound as {@code log}.
  * </p>
  *
  * @config function
  */
 @XStreamAlias("function")
 @AdapterComponent
-@ComponentProfile(summary = "Condition that makes use of the built in nashorn scripting engine for condition evaluation", tag = "condition,service")
+@ComponentProfile(summary = "Condition that makes use of the javascript scripting engine for condition evaluation", tag = "condition,service")
 public class ConditionFunction extends ConditionImpl {
 
   private transient ScriptEngine engine = null;
 
+  /**
+   * Definition of the function to evaluate the condition
+   */
   @MarshallingCDATA
+  @Getter
+  @Setter
   private String definition;
 
   static {
-    System.setProperty("polyglot.js.nashorn-compat", "true");
+    ScriptEngineUtils.nashornCompat();
   }
-  
+
   public ConditionFunction() {
 
   }
@@ -79,8 +86,7 @@ public class ConditionFunction extends ConditionImpl {
   @Override
   public void init() throws CoreException {
     try {
-      ScriptEngineManager  manager = new ScriptEngineManager(this.getClass().getClassLoader());
-      engine = Args.notNull(manager.getEngineByName("javascript"), "graaljs engine");
+      engine = ScriptEngineUtils.getEngineByName(ScriptEngineUtils.JAVASCRIPT, this.getClass().getClassLoader());
       engine.eval(definition);
       Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
       bindings.put("log", log);
@@ -89,11 +95,4 @@ public class ConditionFunction extends ConditionImpl {
     }
   }
 
-  public String getDefinition() {
-    return definition;
-  }
-
-  public void setDefinition(String f) {
-    this.definition = f;
-  }
 }

--- a/src/main/java/com/adaptris/core/scripting/utils/ScriptEngineUtils.java
+++ b/src/main/java/com/adaptris/core/scripting/utils/ScriptEngineUtils.java
@@ -1,0 +1,25 @@
+package com.adaptris.core.scripting.utils;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+
+import com.adaptris.core.util.Args;
+
+public final class ScriptEngineUtils {
+
+  public static final String JAVASCRIPT = "javascript";
+
+  private ScriptEngineUtils() {
+  }
+
+  public static void nashornCompat() {
+    System.setProperty("polyglot.js.nashorn-compat", "true");
+  }
+
+  public static ScriptEngine getEngineByName(String language, ClassLoader classLoader) {
+    ScriptEngineManager engineManager = new ScriptEngineManager(classLoader);
+    String error = String.format("getEngineByName(\'%s\')", language);
+    return Args.notNull(engineManager.getEngineByName(language), error);
+  }
+
+}

--- a/src/test/java/com/adaptris/core/scripting/utils/ScriptEngineUtilsTest.java
+++ b/src/test/java/com/adaptris/core/scripting/utils/ScriptEngineUtilsTest.java
@@ -1,0 +1,40 @@
+package com.adaptris.core.scripting.utils;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.util.Args;
+
+public final class ScriptEngineUtilsTest {
+
+  public static ScriptEngine getEngineByName(String language, ClassLoader classLoader) {
+    ScriptEngineManager engineManager = new ScriptEngineManager(classLoader);
+    String error = String.format("getEngineByName(\'%s\')", language);
+    return Args.notNull(engineManager.getEngineByName(language), error);
+  }
+
+  @Test
+  public void testGetEngineByNameJavascript() {
+    ScriptEngine engine = ScriptEngineUtils.getEngineByName("javascript", this.getClass().getClassLoader());
+
+    assertNotNull(engine);
+  }
+
+  @Test
+  public void testGetEngineByNameBeanshell() {
+    ScriptEngine engine = ScriptEngineUtils.getEngineByName("beanshell", this.getClass().getClassLoader());
+
+    assertNotNull(engine);
+  }
+
+  @Test
+  public void testGetEngineByNameDoesntExist() {
+    assertThrows(IllegalArgumentException.class, () -> ScriptEngineUtils.getEngineByName("doesntexist", this.getClass().getClassLoader()));
+  }
+
+}


### PR DESCRIPTION
## Motivation

Spotbugs fails because the new FileReader for the script file should specify the charset.

## Modification

- Add the charset when creating the new FileReader for the script file.
- Use lombok

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.

## Result

There is a new property to specify the encoding of the script file

## Testing

Tests should pass.
