### PR TITLE
updated owasp dependency check with oss credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id "nebula.optional-base" version "7.0.0"
   id "com.github.spotbugs" version "6.1.11"
   id "org.sonarqube" version "6.0.1.5171"
-  id "org.owasp.dependencycheck" version "12.1.1"
+  id "org.owasp.dependencycheck" version "12.1.9"
   id "io.freefair.lombok" version "8.13.1"
 }
 
@@ -324,6 +324,10 @@ dependencyCheck  {
   }
   analyzers {
     assemblyEnabled=false
+    ossIndex {
+      username = System.getenv("OSS_INDEX_USERNAME")
+      password = System.getenv("OSS_INDEX_PASSWORD")
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation

Fix build.

## Modification

Added env vars for OSS index which is a dependency of OWASP dependency check.

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

No impact.
